### PR TITLE
Support LINKER_USE_RPATH variable

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+epics-debhelper (8.12) unstable; urgency=medium
+
+  * Use LINKER_USE_RPATH instead of USE_RPATH
+  * Update package maintainer, uploaders
+  * Bump up package standards version to 3.9.6
+  * Add ${misc:Depends} to dependencies
+
+ -- Martin Konrad <konrad@frib.msu.edu>  Wed, 06 Jan 2016 15:05:16 -0800
+
 epics-debhelper (8.11) unstable; urgency=medium
 
   * dh_rtems: dpkg --print-avail may sometimes incorrectly report

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Uploaders: Michael Davidsaver <mdavidsaver@gmail.com>,
            Ralph Lange <Ralph.Lange@gmx.de>
 Build-Depends: debhelper (>= 7.0.50~),
                perl (>= 5.10.0),
-Standards-Version: 3.9.4
+Standards-Version: 3.9.6
 Homepage: http://pubweb.bnl.gov/~mdavidsaver
 
 Package: epics-debhelper

--- a/debian/control
+++ b/debian/control
@@ -1,8 +1,9 @@
 Source: epics-debhelper
 Section: devel
 Priority: optional
-Maintainer: Michael Davidsaver <mdavidsaver@bnl.gov>
-Uploaders: Ralph Lange <Ralph.Lange@gmx.de>
+Maintainer: Martin Konrad <konrad@frib.msu.edu>
+Uploaders: Michael Davidsaver <mdavidsaver@gmail.com>,
+           Ralph Lange <Ralph.Lange@gmx.de>
 Build-Depends: debhelper (>= 7.0.50~),
                perl (>= 5.10.0),
 Standards-Version: 3.9.4

--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Homepage: http://pubweb.bnl.gov/~mdavidsaver
 Package: epics-debhelper
 Architecture: all
 Depends: ${perl:Depends}, perl (>= 5.10.0),
-         debhelper (>= 7.0.50~), libparse-debcontrol-perl,
+         ${misc:Depends}, debhelper (>= 7.0.50~), libparse-debcontrol-perl,
          libtie-ixhash-perl,
 Conflicts: rtems-debhelper (<< 6~)
 Description: Helper for building EPICS packages
@@ -23,7 +23,7 @@ Description: Helper for building EPICS packages
 
 Package: rtems-debhelper
 Architecture: all
-Depends: epics-debhelper (= ${source:Version})
+Depends: ${misc:Depends}, epics-debhelper (= ${source:Version})
 Description: Helper for building EPICS packages (transitional package)
  A helper script to calculate package dependencies
  for RTEMS packages.  Only needed when creating packages.

--- a/lib/Debian/Debhelper/Buildsystem/epicsmake.pm
+++ b/lib/Debian/Debhelper/Buildsystem/epicsmake.pm
@@ -59,8 +59,8 @@ sub do_make {
     verbose_print("export PATH=$ENV{PATH}");
     verbose_print("export LD_LIBRARY_PATH=$ENV{LD_LIBRARY_PATH}");
 
-    unshift(@_, ("USE_RPATH=NO", "SHRLIB_VERSION=${sov}",
-            "EPICS_HOST_ARCH=$ENV{EPICS_HOST_ARCH}",
+    unshift(@_, ("LINKER_USE_RPATH=NO", "USE_RPATH=NO",
+            "SHRLIB_VERSION=${sov}", "EPICS_HOST_ARCH=$ENV{EPICS_HOST_ARCH}",
             "CROSS_COMPILER_TARGET_ARCHS=$targets"));
     $this->SUPER::do_make(@_);
 }


### PR DESCRIPTION
Let's set both the new LINKER_USE_RPATH and the old USE_RPATH variable to "NO". This way we can get rid of [one of our patches](https://github.com/epicsdeb/epics-base/blob/master/debian/patches/0001-Compatibility-USE_RPATH-make-variable.patch) in the patch queue for 3.15. The resulting epics-debhelper code should work for building both base 3.15 and 3.14.

Note that I'm also "hijacking" this package (becoming maintainer for the time being) since Michael is not able to take care of it on a regular basis anymore.