### PR TITLE
Detect installed version of EPICS Base correctly

### DIFF
--- a/dh_epicsdep
+++ b/dh_epicsdep
@@ -25,17 +25,11 @@ packages which should match the libepics* dependency.
 
 init();
 
-my $depinfo = `dpkg --print-avail epics-dev`;
+my $ver = `dpkg-query --show --showformat='\${Version}' epics-dev`;
 # The following requires perl >= 5.10
 if( ${^CHILD_ERROR_NATIVE} != 0 ) {
 	die "Package name epics-dev not installed";
 }
-
-my $parser = new Parse::DebControl;
-
-my $control = $parser->parse_mem($depinfo, { useTieIxHash => 'true' });
-
-my $ver = $control->[0]->{"Version"};
 
 # remove deb revision
 $ver =~ s/-[^-]+$//;


### PR DESCRIPTION
Looking at https://github.com/epicsdeb/epics-debhelper/blob/master/dh_epicsdep#L28 I think we need to detect which version of EPICS Base is _installed_, not which version is _available_ for installation. So I think we should rather use `dpkg-query --show --showformat='${Version}' epics-dev` to determine the epics-base version we are building against. This closes #4.