### PR TITLE
Fix broken regex for filtering Debian version

### DIFF
--- a/lib/Debian/Debhelper/Dh_Epics.pm
+++ b/lib/Debian/Debhelper/Dh_Epics.pm
@@ -30,10 +30,11 @@ sub epics_sover {
         return $ENV{SHRLIB_VERSION};
     }
 
+    # format of the version: [epoch:]upstream_version[-debian_revision]
     my $version=`dpkg-parsechangelog`;
 
-    # [IGNORE:]INTERESTING[-IGNORE]
-    my ($ver) = $version =~ m/Version:\s*(?:\d*:)?([\d:.+-~]*)/m;
+    # extract upstream_version and debian_revision
+    my ($ver) = $version =~ m/Version:\s*(?:\d*:)?([0-9a-zA-Z.+\-:~]*)/m;
 
     if($ver =~ /(.*)-[^-]*/) { # strip debian version
         ($ver) = $1;


### PR DESCRIPTION
Allow letters as part of the upstream version number (as defined
by the Debian Policy Manual). Additionally, the character class
of the old code contained an unquoted "-" which caused undesired
behavior.
