### PR TITLE
Strip version suffix from so version

### DIFF
--- a/lib/Debian/Debhelper/Dh_Epics.pm
+++ b/lib/Debian/Debhelper/Dh_Epics.pm
@@ -30,10 +30,11 @@ sub epics_sover {
         return $ENV{SHRLIB_VERSION};
     }
 
+    # format of the version: [epoch:]upstream_version[-debian_revision]
     my $version=`dpkg-parsechangelog`;
 
-    # [IGNORE:]INTERESTING[-IGNORE]
-    my ($ver) = $version =~ m/Version:\s*(?:\d*:)?([\d:.+-~]*)/m;
+    # extract upstream_version and debian_revision
+    my ($ver) = $version =~ m/Version:\s*(?:\d*:)?([0-9a-zA-Z.+\-:~]*)/m;
 
     if($ver =~ /(.*)-[^-]*/) { # strip debian version
         ($ver) = $1;

--- a/lib/Debian/Debhelper/Dh_Epics.pm
+++ b/lib/Debian/Debhelper/Dh_Epics.pm
@@ -30,13 +30,17 @@ sub epics_sover {
         return $ENV{SHRLIB_VERSION};
     }
 
-    # format of the version: [epoch:]upstream_version[-debian_revision]
+    # format of the version: [epoch:]upstream_version[-debian_revision][suffix]
     my $version=`dpkg-parsechangelog`;
 
     # extract upstream_version and debian_revision
     my ($ver) = $version =~ m/Version:\s*(?:\d*:)?([0-9a-zA-Z.+\-:~]*)/m;
 
-    if($ver =~ /(.*)-[^-]*/) { # strip debian version
+    # strip suffix if present (suffix starts with ":", "+", or "~")
+    ($ver) = $ver =~ m/(?:\d*:)?([0-9a-zA-Z.\-]+)[:\+~].*/m;
+
+    # strip debian_revision if present
+    if($ver =~ /(.*)-[^-]*/) {
         ($ver) = $1;
     }
     return $ver;


### PR DESCRIPTION
Do not include version suffixes like "+deb8u1", "+git20160525-1", or "~beta2-3" in the file name of the shared library. These parts of the name usually are not part of the version number. The often contain a build number or a date which might be updated without any changes to the API. In this case we want to keep the name of the shared lib the same to simplify upgrading the library package.